### PR TITLE
Update documentation link in front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@ development and support of the control and data acquisition systems.
 Sardana development was started at the <a class="reference external" href="http://www.albasynchrotron.es">ALBA</a> synchrotron and today is
 supported by a larger community which includes several other laboratories
 and individuals (<a class="reference external" href="http://www.albasynchrotron.es">ALBA</a>, <a class="reference external" href="http://www.desy.de">DESY</a>, <a class="reference external" href="http://www.maxiv.se/">MaxIV</a>, <a class="reference external" href="http://www.synchrotron.uj.edu.pl/en_GB/">Solaris</a>, <a class="reference external" href="http://esrf.eu">ESRF</a>).</p>
-<p>You can download Sardana from <a class="reference external" href="http://pypi.python.org/pypi/sardana">PyPi</a>, check its <a class="reference external" href="http://sardana.readthedocs.org">Documentation</a> or get support
+<p>You can download Sardana from <a class="reference external" href="http://pypi.python.org/pypi/sardana">PyPi</a>, check its <a class="reference external" href="https://sardana-controls.org/docs.html">Documentation</a> or get support
 from its community and the latest code from the
 <a class="reference external" href="https://github.com/sardana-org/sardana">project page</a>.</p>
 <div class="section" id="projects-related-to-sardana">


### PR DESCRIPTION
When I tried to open the documentation with the old link, there was a 404